### PR TITLE
Specify the destination of bugs & support cases

### DIFF
--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -162,11 +162,11 @@ Browser: ${window.navigator.userAgent}
 `);
   return _.isEmpty(prerelease)
     ? {
-        label: 'Open Support Case',
+        label: 'Open Support Case with Red Hat',
         href: `https://access.redhat.com/support/cases/#/case/new?product=OpenShift%20Container%20Platform&version=${major}.${minor}&clusterId=${cv.spec.clusterID}`,
       }
     : {
-        label: 'Report Bug',
+        label: 'Report Bug to Red Hat',
         href: `https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&version=${bugzillaVersion}&cf_environment=${environment}`,
       };
 };


### PR DESCRIPTION
This adds verbiage to clarify that bugs and support cases will be opened with Red Hat (which was implicit before). We have seen a few instances of customers opening support cases with Red Hat for IBM products because the link was present in the console; by adding this & working with IBM to leverage the ConsoleLink CRD to add a "Open Cloud Pak Support Case with IBM" link to help provide an alternative option.